### PR TITLE
Fix UB word-0 corruption (MMVR handoff) + lock chain stage checks

### DIFF
--- a/docs/issues/ub-word0-corruption-issue.md
+++ b/docs/issues/ub-word0-corruption-issue.md
@@ -1,0 +1,48 @@
+## Summary
+In long layer-by-layer MNIST cocotb flow, Unified Buffer word `addr=0` can be corrupted before execution, causing channel-local output mismatches (notably conv2 channels 0-3).
+
+## Observed Behavior
+- `test_mnist.py` previously failed at `conv2` with large mismatches while conv1 was bit-perfect.
+- Debug comparison showed only UB word `0` diverged from compiler-produced payload.
+- That word is the first packed bias word for conv2 (channels 0-3), consistent with mismatch pattern.
+
+## Evidence
+- Compiler payload expected at UB[0] for conv2 bias:
+  - `[-4, 181, -298, -254]` packed into first 128-bit word.
+- Runtime dump (`verification/cocotb/ub_dump_rtl.hex`) showed different value at UB[0], while other early words matched.
+- Re-writing bias words immediately before `RUN` made conv2/conv3/fc bit-perfect.
+
+## Reproduction
+1. Use current MNIST artifacts (`npu_export/manifest.json`, `mnist_sample.npy`).
+2. In `verification/cocotb/test_mnist.py`, temporarily disable the defensive bias reload block before `RUN`.
+3. Run:
+   - `make -C verification/cocotb -f Makefile.npu MODULE=test_mnist`
+4. Observe:
+   - conv1 passes, conv2 mismatch appears.
+   - Inspect `verification/cocotb/ub_dump_rtl.hex`; UB word 0 differs from compiled conv2 bias word.
+
+## Expected Behavior
+- UB contents written by host interface remain stable until consumed.
+- No silent corruption of `addr=0` (or any UB location).
+
+## Current Mitigation
+- `test_mnist.py` rewrites bias payload right before `RUN` to enforce deterministic behavior.
+
+## Investigation Areas
+- MMIO write ordering / doorbell timing.
+- Control-unit latching behavior around command transitions.
+- Host driver protocol assumptions for write/read interleaving.
+- Any special-case behavior for UB base addresses.
+
+## Root Cause (March 10, 2026)
+- In `CTRL_READ_WAIT`, control continuously asserted `mmvr_wr_en`.
+- In `mmio_interface.sv`, the internal `mmvr_wr_en` path had priority over host MMVR writes.
+- Therefore, the first `WRITE_MEM` command issued while CU was still in `READ_WAIT` (common after UB debug reads) had its host payload overwritten by stale readback data.
+- In MNIST flow, this first post-read write is `Bias` at `UB[0]`, producing the observed word-0 corruption and conv2 channel-0..3 mismatch.
+
+## Fix (March 10, 2026)
+- `mmio_interface.sv` now gives host MMVR writes priority over internal `mmvr_wr_en` updates.
+- Added deterministic cocotb regression `test_mmio_readwrite_handoff.py`:
+  - Repro sequence: `READ_MEM` -> immediate `WRITE_MEM`.
+  - Asserts first post-read write data is preserved.
+- `run_all_tests.sh` now runs this regression first.

--- a/rtl/mmio_interface.sv
+++ b/rtl/mmio_interface.sv
@@ -56,9 +56,13 @@ module mmio_interface (
         end
       end
 
-      // Internal override (TPU writes to Host)
-      // If both write in same cycle, Internal wins for MMVR
-      if (mmvr_wr_en) begin
+      // Internal MMVR update (READ_MEM result).
+      // Host writes to MMVR must take precedence, otherwise the first WRITE_MEM
+      // issued from READ_WAIT can be overwritten by stale readback data.
+      if (mmvr_wr_en &&
+          !(host_wr_en &&
+            host_addr >= `REG_MMVR &&
+            host_addr < (`REG_MMVR + (`BUFFER_WIDTH / 8)))) begin
         mmvr_reg <= mmvr_in;
       end
     end

--- a/software/workload/complex_chain_gen.py
+++ b/software/workload/complex_chain_gen.py
@@ -123,15 +123,15 @@ def generate_complex_chain():
         
         # 3. Saturation (Output Precision)
         golden_output = clip_and_quantize(shifted, out_prec)
+
+        # Verify every stage explicitly (not only final output).
+        prog.add_expected_result(layer_name, golden_output)
         
         current_input = layer_name
         current_in_prec = out_prec 
         golden_input = golden_output
 
     prog.halt()
-    
-    # Final Result
-    prog.add_expected_result("L7", golden_input)
 
     output_path = "complex_chain.npu"
     prog.save_npu(output_path)

--- a/verification/cocotb/run_all_tests.sh
+++ b/verification/cocotb/run_all_tests.sh
@@ -12,6 +12,11 @@ echo "🚀 Starting TinyNPU All-Tests Suite..."
 # Ensure clean start
 rm -f results.xml
 
+# Test 0: MMIO read->write handoff regression (issue #2)
+echo "📂 Running: test_mmio_readwrite_handoff.py"
+MODULE=test_mmio_readwrite_handoff make -f Makefile.npu > /dev/null 2>&1
+echo "✅ test_mmio_readwrite_handoff.py: PASSED"
+
 # Test 1: Simple Chain
 echo "📂 Running: simple_chain.npu"
 cd $WORKLOAD_DIR

--- a/verification/cocotb/test_mmio_readwrite_handoff.py
+++ b/verification/cocotb/test_mmio_readwrite_handoff.py
@@ -1,0 +1,57 @@
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import ClockCycles
+
+import npu_driver
+
+
+def pack_word(vec16):
+    word = 0
+    for i, v in enumerate(vec16):
+        word |= (v & 0xFFFF) << (i * 16)
+    return word
+
+
+async def write_ub_word(dut, addr, word):
+    await npu_driver.write_reg(dut, npu_driver.REG_ADDR, addr, 16)
+    await npu_driver.write_reg(dut, npu_driver.REG_CMD, 0x01, 8)  # WRITE_MEM
+    await npu_driver.write_reg(dut, npu_driver.REG_MMVR, word, 128)
+
+
+async def read_ub_word(dut, addr):
+    vec = await npu_driver.read_ub_vector(dut, addr, 8)
+    return pack_word(vec)
+
+
+@cocotb.test()
+async def test_mmio_readwrite_handoff(dut):
+    """Regression: first WRITE_MEM after READ_WAIT must not use stale MMVR data."""
+    clock = Clock(dut.clk, 10, units="ns")
+    cocotb.start_soon(clock.start())
+    dut.rst_n.value = 0
+    await ClockCycles(dut.clk, 5)
+    dut.rst_n.value = 1
+    await ClockCycles(dut.clk, 2)
+
+    src_addr = 5
+    dst_addr = 0
+    src_word = 0x112233445566778899AABBCCDDEEFF00
+    dst_word = 0xFEDCBA98765432100123456789ABCDEF
+
+    # Seed source word and verify it.
+    await write_ub_word(dut, src_addr, src_word)
+    got_src = await read_ub_word(dut, src_addr)
+    assert got_src == src_word, (
+        f"Seed readback mismatch at src_addr={src_addr}: "
+        f"expected 0x{src_word:032x}, got 0x{got_src:032x}"
+    )
+
+    # Critical sequence: while CU is in READ_WAIT after readback above,
+    # issue first WRITE_MEM. This previously wrote stale MMVR contents.
+    await write_ub_word(dut, dst_addr, dst_word)
+
+    got_dst = await read_ub_word(dut, dst_addr)
+    assert got_dst == dst_word, (
+        "MMIO handoff bug: first WRITE_MEM after READ_WAIT used stale MMVR data. "
+        f"expected 0x{dst_word:032x}, got 0x{got_dst:032x}"
+    )

--- a/verification/cocotb/test_mnist.py
+++ b/verification/cocotb/test_mnist.py
@@ -38,6 +38,8 @@ async def test_mnist_full(dut):
     
     dut._log.info("--- Starting Bit-Perfect MNIST NPU Verification ---")
 
+    reload_bias_before_run = os.getenv("TINYNPU_DEFENSIVE_BIAS_RELOAD", "0") == "1"
+
     for i, layer in enumerate(manifest['layers']):
         name = layer['name']
         ltype = layer['type']
@@ -84,15 +86,16 @@ async def test_mnist_full(dut):
             await npu_driver.write_reg(dut, npu_driver.REG_CMD, 0x01, 8)
             await npu_driver.write_reg(dut, npu_driver.REG_MMVR, inst >> 128, 128)
 
-        # Defensive reload: we have observed sporadic corruption of UB word 0 in long flows.
-        # Re-writing bias payload right before RUN keeps layer behavior deterministic.
-        bias_sym = prog.symbols.get("Bias")
-        if bias_sym is not None:
-            for off in range(bias_sym.word_count):
-                word = binary["ub"][bias_sym.addr + off]
-                await npu_driver.write_reg(dut, npu_driver.REG_ADDR, bias_sym.addr + off, 16)
-                await npu_driver.write_reg(dut, npu_driver.REG_CMD, 0x01, 8)
-                await npu_driver.write_reg(dut, npu_driver.REG_MMVR, word, 128)
+        # Historical mitigation for UB word-0 instability.
+        # Default is OFF; set TINYNPU_DEFENSIVE_BIAS_RELOAD=1 to re-enable.
+        if reload_bias_before_run:
+            bias_sym = prog.symbols.get("Bias")
+            if bias_sym is not None:
+                for off in range(bias_sym.word_count):
+                    word = binary["ub"][bias_sym.addr + off]
+                    await npu_driver.write_reg(dut, npu_driver.REG_ADDR, bias_sym.addr + off, 16)
+                    await npu_driver.write_reg(dut, npu_driver.REG_CMD, 0x01, 8)
+                    await npu_driver.write_reg(dut, npu_driver.REG_MMVR, word, 128)
 
         # Run
         await npu_driver.write_reg(dut, npu_driver.REG_ARG, im_base, 32)


### PR DESCRIPTION
Summary:\n- Fix MMVR read/write handoff bug that could corrupt the first WRITE_MEM payload after READ_WAIT (root cause of UB word-0 corruption).\n- Add deterministic cocotb regression test_mmio_readwrite_handoff.py.\n- Run that regression first in verification/cocotb/run_all_tests.sh.\n- Keep MNIST defensive bias reload as opt-in via TINYNPU_DEFENSIVE_BIAS_RELOAD=1 (default off).\n- Update complex chain generator to emit expected results for every stage (L1..L7), so intermediate layers including L2 are explicitly verified.\n- Document root cause and fix in docs/issues/ub-word0-corruption-issue.md.\n\nValidation run:\n- CCACHE_DISABLE=1 make -C verification/cocotb -f Makefile.npu MODULE=test_mmio_readwrite_handoff\n- CCACHE_DISABLE=1 TINYNPU_DEFENSIVE_BIAS_RELOAD=0 make -C verification/cocotb -f Makefile.npu MODULE=test_mnist\n- cd verification/cocotb && CCACHE_DISABLE=1 bash run_all_tests.sh\n- CCACHE_DISABLE=1 NPU_FILE=../../software/workload/complex_chain.npu make -C verification/cocotb -f Makefile.npu MODULE=test_npu (PASS includes L1..L7, including L2)


Fixes: #2 