### PR TITLE
Add UB read arbiter to remove unrealistic third read port

### DIFF
--- a/rtl/ubss.sv
+++ b/rtl/ubss.sv
@@ -89,9 +89,39 @@ module ubss #(
     
     // Wire up the Skewer ports
     logic [`BUFFER_WIDTH-1:0] skewer_input_data;
+    logic [`BUFFER_WIDTH-1:0] skewer_input_data_comb;
     logic [`BUFFER_WIDTH-1:0] skewer_weight_data;
     logic                     skewer_input_first, skewer_input_last;
     logic                     skewer_weight_first, skewer_weight_last;
+    logic [`ADDR_WIDTH-1:0]   ub_port_a_addr;
+    logic                     ub_port_a_first_in, ub_port_a_last_in;
+    logic [`ADDR_WIDTH-1:0]   ub_port_b_addr;
+    logic                     ub_port_b_first_in, ub_port_b_last_in;
+
+    // Read-port arbiter:
+    // - Port A is shared between SA input stream and CU random reads.
+    // - Port B serves SA weight stream.
+    // This keeps UB read addressing to 2 ports total.
+    always_comb begin
+        if (compute_enable) begin
+            ub_port_a_addr     = sa_input_addr;
+            ub_port_a_first_in = sa_input_first;
+            ub_port_a_last_in  = sa_input_last;
+            ub_port_b_addr     = sa_weight_addr;
+            ub_port_b_first_in = sa_weight_first;
+            ub_port_b_last_in  = sa_weight_last;
+        end else begin
+            ub_port_a_addr     = cu_addr;
+            ub_port_a_first_in = 1'b0;
+            ub_port_a_last_in  = 1'b0;
+            ub_port_b_addr     = '0;
+            ub_port_b_first_in = 1'b0;
+            ub_port_b_last_in  = 1'b0;
+        end
+    end
+
+    // CU reads observe Port A combinational tap when arbiter routes CU onto Port A.
+    assign cu_rdata = cu_req && !cu_wr_en ? skewer_input_data_comb : '0;
 
     unified_buffer #(
         .INIT_FILE(UB_INIT_FILE)
@@ -103,25 +133,22 @@ module ubss #(
         .wr_addr         (cu_addr),
         .wr_data         (ub_final_wdata),
         
-        // Port A: Input Matrix Stream
-        .input_first_in  (sa_input_first),
-        .input_last_in   (sa_input_last),
-        .input_addr      (sa_input_addr),
+        // Port A: SA Input Stream or CU Read (arbiter selected)
+        .input_first_in  (ub_port_a_first_in),
+        .input_last_in   (ub_port_a_last_in),
+        .input_addr      (ub_port_a_addr),
         .input_first_out (skewer_input_first),
         .input_last_out  (skewer_input_last),
         .input_data      (skewer_input_data),
+        .input_data_comb (skewer_input_data_comb),
         
         // Port B: Weight Matrix Stream
-        .weight_first_in (sa_weight_first),
-        .weight_last_in  (sa_weight_last),
-        .weight_addr     (sa_weight_addr),
+        .weight_first_in (ub_port_b_first_in),
+        .weight_last_in  (ub_port_b_last_in),
+        .weight_addr     (ub_port_b_addr),
         .weight_first_out(skewer_weight_first),
         .weight_last_out (skewer_weight_last),
-        .weight_data     (skewer_weight_data),
-
-        // CU Random Access
-        .cu_rd_addr      (cu_addr),
-        .cu_rd_data      (cu_rdata)
+        .weight_data     (skewer_weight_data)
     );
     
     // ========================================================================

--- a/rtl/unified_buffer.sv
+++ b/rtl/unified_buffer.sv
@@ -19,6 +19,7 @@ module unified_buffer #(
     output logic                     input_first_out,  // Delayed to match data
     output logic                     input_last_out,
     output logic [`BUFFER_WIDTH-1:0] input_data,
+    output logic [`BUFFER_WIDTH-1:0] input_data_comb,
 
     // Read interface for weights (feeds systolic array vertically)
     input  logic                     weight_first_in,
@@ -26,18 +27,14 @@ module unified_buffer #(
     input  logic [  `ADDR_WIDTH-1:0] weight_addr,
     output logic                     weight_first_out,
     output logic                     weight_last_out,
-    output logic [`BUFFER_WIDTH-1:0] weight_data,
-
-    // NEW: Dedicated Read Port for Control Unit / MMIO
-    input  logic [`ADDR_WIDTH-1:0]   cu_rd_addr,
-    output logic [`BUFFER_WIDTH-1:0] cu_rd_data
+    output logic [`BUFFER_WIDTH-1:0] weight_data
 );
 
   // Memory: BUFFER_DEPTH rows × BUFFER_WIDTH bits per row
   logic [`BUFFER_WIDTH-1:0] memory[`BUFFER_DEPTH-1:0];
 
-  // Random access read (combinational for simplicity in this CU)
-  assign cu_rd_data = memory[cu_rd_addr];
+  // Port A combinational read tap (used by CU when arbiter maps CU onto Port A).
+  assign input_data_comb = memory[input_addr];
 
   // Write logic (negedge for timing hygiene)
   always_ff @(negedge clk) begin


### PR DESCRIPTION
Summary:\n- Remove dedicated CU read-address port from unified buffer.\n- Add read-port arbitration in ubss so Port A is shared between SA input stream and CU reads, while Port B remains the SA weight stream.\n- Keep write path unchanged.\n- This enforces a realistic 2-read-port memory model instead of an effective 3-read-port model.\n\nWhy:\n- Addresses issue #6: UB previously behaved as if it had three independent read clients.\n\nValidation (all run individually):\n- MODULE=test_mmio_readwrite_handoff\n- NPU_FILE=../../software/workload/simple_chain.npu MODULE=test_npu\n- NPU_FILE=../../software/workload/move_test.npu MODULE=test_npu\n- NPU_FILE=../../software/workload/bias_test.npu MODULE=test_npu\n- NPU_FILE=../../software/workload/dnn_example.npu MODULE=test_npu\n- NPU_FILE=../../software/workload/mixed_test.npu MODULE=test_npu\n- NPU_FILE=../../software/workload/mixed_stress.npu MODULE=test_npu\n- NPU_FILE=../../software/workload/relu_test.npu MODULE=test_npu\n- NPU_FILE=../../software/workload/complex_chain.npu MODULE=test_npu (L1..L7 all matched)\n- MODULE=test_mnist\n\nCloses #6