### PR TITLE
Add optional full-FSM perf observability

### DIFF
--- a/docs/perf_observability.md
+++ b/docs/perf_observability.md
@@ -1,0 +1,71 @@
+## Optional Perf Observability
+
+This NPU includes an optional performance/debug instrumentation layer for the control FSM.
+
+### Design Goals
+
+- No compiler dependency.
+- No functional behavior change.
+- Compile-time removable.
+- Full control-state visibility for cycle analysis.
+
+### What It Tracks
+
+When `PERF_ENABLE=1`, the control unit exposes:
+
+- `perf_total_cycles`: total cycles since reset
+- `perf_state_cycles_flat`: 64-bit cycle counter for every control FSM state
+- `perf_state_entries_flat`: 64-bit entry counter for every control FSM state
+- `perf_state_id`: current FSM state ID
+
+Tracked states:
+
+- `CTRL_IDLE`
+- `CTRL_HOST_WRITE`
+- `CTRL_HOST_READ`
+- `CTRL_READ_WAIT`
+- `CTRL_FETCH`
+- `CTRL_DECODE`
+- `CTRL_EXEC_MOVE`
+- `CTRL_EXEC_MATMUL`
+- `CTRL_MM_CLEAR`
+- `CTRL_MM_FEED`
+- `CTRL_MM_WAIT`
+- `CTRL_MM_LOAD_BIAS`
+- `CTRL_MM_DRAIN_SA`
+- `CTRL_MM_WRITEBACK`
+- `CTRL_HALT`
+
+### Build Modes
+
+- Default build: `PERF_ENABLE=0`
+  - counters stay inactive
+  - normal execution path remains unchanged
+- Perf/debug build: `PERF_ENABLE=1`
+  - counters are enabled for cocotb or waveform inspection
+
+### Running The Perf Test
+
+From `verification/cocotb`:
+
+```sh
+CCACHE_DISABLE=1 USER_EXTRA_ARGS='-GPERF_ENABLE=1' MODULE=test_perf_observability make -f Makefile.npu
+```
+
+Optional workload override:
+
+```sh
+CCACHE_DISABLE=1 USER_EXTRA_ARGS='-GPERF_ENABLE=1' MODULE=test_perf_observability NPU_FILE=../../software/workload/simple_chain.npu make -f Makefile.npu
+```
+
+### How To Use The Counters
+
+For phase-level analysis, snapshot counters before and after the region of interest and take a delta.
+
+Example:
+
+- snapshot after program load
+- snapshot after `HALT`
+- subtract to get execution-only state costs
+
+This is intended as a debug/perf tool, not a required production interface.

--- a/rtl/control_top.sv
+++ b/rtl/control_top.sv
@@ -1,7 +1,8 @@
 `include "defines.sv"
 
 module control_top #(
-    parameter IM_INIT_FILE = ""
+    parameter IM_INIT_FILE = "",
+    parameter PERF_ENABLE = 0
 ) (
     input  logic clk,
     input  logic rst_n,
@@ -93,7 +94,9 @@ module control_top #(
     );
 
     // Control Unit Instance
-    control_unit u_cu (
+    control_unit #(
+        .PERF_ENABLE(PERF_ENABLE)
+    ) u_cu (
         .clk            (clk),
         .rst_n          (rst_n),
         .cmd_in         (cmd_bus),

--- a/rtl/control_unit.sv
+++ b/rtl/control_unit.sv
@@ -1,6 +1,8 @@
 `include "defines.sv"
 
-module control_unit (
+module control_unit #(
+    parameter PERF_ENABLE = 0
+) (
     input logic clk,
     input logic rst_n,
 
@@ -73,6 +75,9 @@ module control_unit (
 
   ctrl_state_t state, next_state;
   logic [`ADDR_WIDTH-1:0] pc, pc_next;
+  localparam int CTRL_STATE_COUNT = 15;
+  localparam int PERF_COUNTER_WIDTH = 64;
+  localparam int PERF_COUNTERS_FLAT_WIDTH = CTRL_STATE_COUNT * PERF_COUNTER_WIDTH;
 
   // Safety Latches for MMIO inputs
   logic [`HOST_DATA_WIDTH-1:0] latched_cmd;
@@ -104,6 +109,21 @@ module control_unit (
   logic [$clog2(`ARRAY_SIZE)-1:0] cycle_cnt, cycle_next;
 
   logic [15:0] m_next, n_next, k_next;
+  logic [PERF_COUNTER_WIDTH-1:0] perf_total_cycles;
+  logic [PERF_COUNTER_WIDTH-1:0] perf_state_cycles [0:CTRL_STATE_COUNT-1];
+  logic [PERF_COUNTER_WIDTH-1:0] perf_state_entries[0:CTRL_STATE_COUNT-1];
+  logic [PERF_COUNTERS_FLAT_WIDTH-1:0] perf_state_cycles_flat;
+  logic [PERF_COUNTERS_FLAT_WIDTH-1:0] perf_state_entries_flat;
+  logic [3:0] perf_state_id;
+
+  assign perf_state_id = state;
+
+  generate
+    for (genvar perf_idx = 0; perf_idx < CTRL_STATE_COUNT; perf_idx++) begin : gen_perf_flatten
+      assign perf_state_cycles_flat[(perf_idx * PERF_COUNTER_WIDTH) +: PERF_COUNTER_WIDTH] = perf_state_cycles[perf_idx];
+      assign perf_state_entries_flat[(perf_idx * PERF_COUNTER_WIDTH) +: PERF_COUNTER_WIDTH] = perf_state_entries[perf_idx];
+    end
+  endgenerate
 
   // --- Sequential State ---
   always_ff @(posedge clk or negedge rst_n) begin
@@ -116,6 +136,14 @@ module control_unit (
       {mm_a_base, mm_b_base, mm_c_base, mm_bias_base, mm_m_total, mm_k_total, mm_n_total} <= '0;
       {mm_shift, mm_multiplier, mm_activation, mm_in_precision, mm_out_precision, mm_write_offset} <= '0;
       {m_idx, n_idx, k_idx, cycle_cnt} <= '0;
+      perf_total_cycles <= '0;
+      for (int perf_i = 0; perf_i < CTRL_STATE_COUNT; perf_i++) begin
+        perf_state_cycles[perf_i] <= '0;
+        perf_state_entries[perf_i] <= '0;
+      end
+      if (PERF_ENABLE) begin
+        perf_state_entries[CTRL_IDLE] <= 64'd1;
+      end
     end else begin
       state <= next_state;
       pc    <= pc_next;
@@ -163,6 +191,14 @@ module control_unit (
         n_idx <= n_next;
         k_idx <= k_next;
         cycle_cnt <= cycle_next;
+      end
+
+      if (PERF_ENABLE) begin
+        perf_total_cycles <= perf_total_cycles + 64'd1;
+        perf_state_cycles[state] <= perf_state_cycles[state] + 64'd1;
+        if (state != next_state) begin
+          perf_state_entries[next_state] <= perf_state_entries[next_state] + 64'd1;
+        end
       end
     end
   end

--- a/rtl/tinynpu_top.sv
+++ b/rtl/tinynpu_top.sv
@@ -2,7 +2,8 @@
 
 module tinynpu_top #(
     parameter IM_INIT_FILE = "",
-    parameter UB_INIT_FILE = ""
+    parameter UB_INIT_FILE = "",
+    parameter PERF_ENABLE = 0
 ) (
     input  logic clk,
     input  logic rst_n,
@@ -48,7 +49,8 @@ module tinynpu_top #(
     end
 
     control_top #(
-        .IM_INIT_FILE(IM_INIT_FILE)
+        .IM_INIT_FILE(IM_INIT_FILE),
+        .PERF_ENABLE(PERF_ENABLE)
     ) u_brain (
         .clk            (clk),
         .rst_n          (rst_n),

--- a/verification/cocotb/Makefile.npu
+++ b/verification/cocotb/Makefile.npu
@@ -19,5 +19,6 @@ export PYTHONPATH := $(PWD)/../..:$(PWD)/../../software/compiler:$(PYTHONPATH)
 
 EXTRA_ARGS += --trace --trace-structs -Wno-fatal -I$(PWD)/../../rtl
 EXTRA_ARGS += -Wno-PINMISSING -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-SELRANGE -Wno-UNOPTFLAT -Wno-CASEINCOMPLETE
+EXTRA_ARGS += $(USER_EXTRA_ARGS)
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/verification/cocotb/perf_utils.py
+++ b/verification/cocotb/perf_utils.py
@@ -1,0 +1,31 @@
+CTRL_STATE_NAMES = [
+    "CTRL_IDLE",
+    "CTRL_HOST_WRITE",
+    "CTRL_HOST_READ",
+    "CTRL_READ_WAIT",
+    "CTRL_FETCH",
+    "CTRL_DECODE",
+    "CTRL_EXEC_MOVE",
+    "CTRL_EXEC_MATMUL",
+    "CTRL_MM_CLEAR",
+    "CTRL_MM_FEED",
+    "CTRL_MM_WAIT",
+    "CTRL_MM_LOAD_BIAS",
+    "CTRL_MM_DRAIN_SA",
+    "CTRL_MM_WRITEBACK",
+    "CTRL_HALT",
+]
+
+PERF_COUNTER_WIDTH = 64
+
+
+def unpack_flat_counters(flat_value):
+    counters = {}
+    mask = (1 << PERF_COUNTER_WIDTH) - 1
+    for idx, name in enumerate(CTRL_STATE_NAMES):
+        counters[name] = (int(flat_value) >> (idx * PERF_COUNTER_WIDTH)) & mask
+    return counters
+
+
+def diff_counters(after, before):
+    return {name: after[name] - before[name] for name in CTRL_STATE_NAMES}

--- a/verification/cocotb/test_perf_observability.py
+++ b/verification/cocotb/test_perf_observability.py
@@ -1,0 +1,116 @@
+import json
+import os
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, ClockCycles
+
+import npu_driver
+from perf_utils import CTRL_STATE_NAMES, diff_counters, unpack_flat_counters
+
+
+def read_perf_snapshot(dut):
+    cu = dut.u_brain.u_cu
+    return {
+        "total": int(cu.perf_total_cycles.value),
+        "cycles": unpack_flat_counters(int(cu.perf_state_cycles_flat.value)),
+        "entries": unpack_flat_counters(int(cu.perf_state_entries_flat.value)),
+    }
+
+
+@cocotb.test()
+async def test_perf_observability(dut):
+    """PERF_ENABLE=1 should expose per-state counters without changing behavior."""
+    assert int(dut.PERF_ENABLE.value) == 1, "Run this test with -GPERF_ENABLE=1"
+
+    npu_file = os.environ.get("NPU_FILE", "simple_chain.npu")
+    if not os.path.exists(npu_file):
+        raise FileNotFoundError(f"NPU program file not found: {npu_file}")
+
+    with open(npu_file, "r") as f:
+        prog = json.load(f)
+
+    clock = Clock(dut.clk, 10, units="ns")
+    cocotb.start_soon(clock.start())
+    dut.rst_n.value = 0
+    await ClockCycles(dut.clk, 5)
+    dut.rst_n.value = 1
+    await ClockCycles(dut.clk, 2)
+
+    config = prog["config"]
+    buffer_width = config["buffer_width"]
+    im_base = config["im_base"]
+
+    # Load UB
+    for addr, word_hex in enumerate(prog["ub"]):
+        word = int(word_hex, 16)
+        await npu_driver.write_reg(dut, npu_driver.REG_ADDR, addr, 16)
+        await npu_driver.write_reg(dut, npu_driver.REG_CMD, 0x01, 8)
+        await npu_driver.write_reg(dut, npu_driver.REG_MMVR, word, buffer_width)
+
+    # Load IM
+    inst_width = 256
+    num_chunks = inst_width // buffer_width
+    for i, inst_hex in enumerate(prog["im"]):
+        inst = int(inst_hex, 16)
+        for c in range(num_chunks):
+            chunk = (inst >> (c * buffer_width)) & ((1 << buffer_width) - 1)
+            await npu_driver.write_reg(dut, npu_driver.REG_ADDR, im_base + (i * num_chunks) + c, 16)
+            await npu_driver.write_reg(dut, npu_driver.REG_CMD, 0x01, 8)
+            await npu_driver.write_reg(dut, npu_driver.REG_MMVR, chunk, buffer_width)
+
+    # Let the final host write retire so the RUN-phase snapshot starts cleanly.
+    await ClockCycles(dut.clk, 2)
+    before = read_perf_snapshot(dut)
+
+    # Run
+    doorbell_addr = npu_driver.REG_MMVR + (buffer_width // 8) - 1
+    await npu_driver.write_reg(dut, npu_driver.REG_ARG, im_base, 32)
+    await npu_driver.write_reg(dut, npu_driver.REG_CMD, 0x03, 8)
+    await npu_driver.write_reg(dut, doorbell_addr, 0, 8)
+
+    for _ in range(100000):
+        dut.host_addr.value = npu_driver.REG_STATUS
+        await RisingEdge(dut.clk)
+        if int(dut.host_rd_data.value) == 0xFF:
+            break
+    else:
+        raise AssertionError("Timeout waiting for HALT")
+
+    after = read_perf_snapshot(dut)
+    delta_total = after["total"] - before["total"]
+    delta_cycles = diff_counters(after["cycles"], before["cycles"])
+    delta_entries = diff_counters(after["entries"], before["entries"])
+
+    dut._log.info("PERF state breakdown for RUN phase:")
+    for name in CTRL_STATE_NAMES:
+        dut._log.info(f"{name}: cycles={delta_cycles[name]} entries={delta_entries[name]}")
+
+    assert delta_total > 0, "Total cycle counter did not advance"
+    assert sum(delta_cycles.values()) == delta_total, "Per-state cycles do not sum to total delta"
+
+    expected_active = [
+        "CTRL_FETCH",
+        "CTRL_DECODE",
+        "CTRL_EXEC_MATMUL",
+        "CTRL_MM_CLEAR",
+        "CTRL_MM_FEED",
+        "CTRL_MM_WAIT",
+        "CTRL_MM_DRAIN_SA",
+        "CTRL_MM_WRITEBACK",
+    ]
+    expected_quiet = [
+        "CTRL_HOST_READ",
+        "CTRL_READ_WAIT",
+        "CTRL_EXEC_MOVE",
+        "CTRL_MM_LOAD_BIAS",
+    ]
+
+    for name in expected_active:
+        assert delta_cycles[name] > 0, f"Expected non-zero cycles for {name}"
+        assert delta_entries[name] > 0, f"Expected non-zero entries for {name}"
+
+    assert delta_entries["CTRL_HALT"] > 0, "Expected HALT to be entered"
+    for name in expected_quiet:
+        assert delta_cycles[name] == 0, f"Expected zero cycles for {name}"
+        assert delta_entries[name] == 0, f"Expected zero entries for {name}"


### PR DESCRIPTION
Summary:\n- add compile-time optional performance observability gated by PERF_ENABLE\n- track total cycles, per-state cycle counts, and per-state entry counts for every control FSM state\n- keep the counters internal to control_unit for cocotb/waveform inspection, with no compiler changes\n- add a perf-specific cocotb regression and helper utilities\n- document how to run perf-enabled builds and interpret counter deltas\n\nScope:\n- all control states are tracked: IDLE, host read/write, fetch/decode, move, matmul, clear/feed/wait/load-bias/drain/writeback, halt\n- default build remains PERF_ENABLE=0\n- perf/debug build uses USER_EXTRA_ARGS='-GPERF_ENABLE=1'\n\nValidation:\n- CCACHE_DISABLE=1 make -C verification/cocotb -f Makefile.npu MODULE=test_npu NPU_FILE=simple_chain.npu\n- CCACHE_DISABLE=1 make -C verification/cocotb -f Makefile.npu MODULE=test_mmio_readwrite_handoff\n- CCACHE_DISABLE=1 make -C verification/cocotb -f Makefile.npu MODULE=test_perf_observability USER_EXTRA_ARGS='-GPERF_ENABLE=1'\n\nNotes:\n- counters are intended as a detachable debug/perf tool\n- counters are sampled by cocotb as internal signals and analyzed as deltas around the phase of interest\n